### PR TITLE
Update control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,8 @@ Homepage: https://cutefishos.com
 
 Package: cutefish-videoplayer
 Architecture: any
-Depends: qml-module-qtquick-controls2,
+Depends: fishui,
+         qml-module-qtquick-controls2,
          qml-module-qtquick2,
          qml-module-qtquick-layouts,
          qml-module-qt-labs-platform,


### PR DESCRIPTION
add fishui to depends as it fails to run without it, fishui description states "every Cutefish application uses it", so this really should be a depends for probably most Cutefish OS apps